### PR TITLE
Fix compile error due to encoding

### DIFF
--- a/style/thesis_style.tex
+++ b/style/thesis_style.tex
@@ -5,7 +5,7 @@
 % SLO: omogoča uporabo slovenskih (latinskih) črk kodiranih v formatu UTF-8
 % ENG: enables the use of slovene (latin) caracters encoded in the UFT-8 format
 \usepackage[utf8x]{inputenc}
-%\inputencoding{utf8}
+\inputencoding{utf8}
 % SLO: naloži, med drugim, slovenske delilne vzorce
 % ENG: loads, among others, slovene dividing patterns
 \usepackage[slovene,english]{babel}


### PR DESCRIPTION
Not sure if this is the "correct" way, but there is an issue in the template. OOTB this template doesn't compile on Overleaf nor on Texmaker.

This PR fixes that.

Snippet from Overleaf:
![Screenshot 2022-12-08 at 5 36 52 PM](https://user-images.githubusercontent.com/14580434/206511299-1f73f10c-a872-497b-931e-087ca23a57b0.png)
